### PR TITLE
Fix compilation after VelocityRa/xbmc#6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SHADERPRESETS_SOURCES src/addon.cpp
                      src/log/Log.cpp
                      src/log/LogAddon.cpp
                      src/log/LogConsole.cpp
+                     src/utils/RarchTranslator.cpp
                      src/utils/StringUtils.cpp
                      src/utils/URIUtils.cpp
                      
@@ -67,6 +68,7 @@ set(SHADERPRESETS_HEADERS src/addon.h
                      src/log/LogConsole.h
                      src/utils/CommonIncludes.h
                      src/utils/CommonMacros.h
+                     src/utils/RarchTranslator.h
                      src/utils/StringUtils.h
                      src/utils/URIUtils.h
                      

--- a/game.shader.presets/addon.xml.in
+++ b/game.shader.presets/addon.xml.in
@@ -7,7 +7,8 @@
   <requires>@ADDON_DEPENDS@</requires>
   <extension
     point="kodi.shader.presets"
-    library_@PLATFORM@="@LIBRARY_FILENAME@"/>
+    library_@PLATFORM@="@LIBRARY_FILENAME@"
+    extensions="cgp|glslp|hlslp"/>
   <extension point="xbmc.addon.metadata">
     <summary lang="en">Shader Preset Support</summary>
     <description lang="en">This library provides support for libretro "meta" shaders, or .cgp files.</description>

--- a/src/addon.h
+++ b/src/addon.h
@@ -22,7 +22,7 @@
 
 #include <kodi/addon-instance/ShaderPreset.h>
 
-#include "depends/gfx/video_shader_parse.h"
+struct rarch_video_shader;
 
 class CShaderPreset
   : public kodi::addon::CAddonBase,
@@ -33,92 +33,17 @@ public:
   virtual ~CShaderPreset();
 
   // CAddonBase overrides
-
   virtual ADDON_STATUS Create() override;
   virtual ADDON_STATUS GetStatus() override;
   virtual ADDON_STATUS SetSetting(const std::string& settingName, const kodi::CSettingValue& settingValue) override;
 
   // CInstanceShaderPreset overrides
-
-  /* Loads a config file. Returns NULL if file doesn't exist.
-  * NULL path will create an empty config file.
-  * Second arg saves its base path.
-   */
-  virtual config_file_t_* ConfigFileNew(const char *path, const char *basePath) override;
-
-  /* Load a config file from a string. */
-  virtual config_file_t_* ConfigFileNewFromString(const char *from_string) override;
-
-  /* Frees config file. */
-  virtual void ConfigFileFree(config_file_t_ *conf) override;
-
-   /**
-  * ShaderPresetRead:
-  * @conf              : Preset file to read from.
-  * @shader            : Shader passes handle.
-  * @addonPath         : Add-on's path, so that shader source is loaded.
-  *                      If nullptr, shader source isn't loaded.
-  *
-  * Loads preset file and all associated state (passes,
-  * textures, imports, etc).
-  *
-  * Returns: true (1) if successful, otherwise false (0).
-  **/
-  virtual bool ShaderPresetRead(config_file_t_ *conf, struct video_shader_ *shader) override;
-
-  /**
-  * ShaderPresetWrite:
-  * @conf              : Preset file to read from.
-  * @shader            : Shader passes handle.
-  *
-  * Saves preset and all associated state (passes,
-  * textures, imports, etc) to disk.
-  **/
-  virtual void ShaderPresetWrite(config_file_t_ *conf, struct video_shader_ *shader) override;
-
-  /**
-  * ShaderPresetResolveRelative:
-  * @shader            : Shader pass handle.
-  * @ref_path          : Relative shader path.
-  *
-  * Resolves relative shader path (@ref_path) into absolute
-  * shader paths.
-  **/
-  virtual void ShaderPresetResolveRelative(struct video_shader_ *shader, const char *ref_path) override;
-
-  /**
-  * ShaderPresetResolveCurrentParameters:
-  * @conf              : Preset file to read from.
-  * @shader            : Shader passes handle.
-  *
-  * Reads the current value for all parameters from config file.
-  *
-  * Returns: true (1) if successful, otherwise false (0).
-  **/
-  virtual bool ShaderPresetResolveCurrentParameters(config_file_t_ *conf, struct video_shader_ *shader) override;
-
-  /**
-  * ShaderPresetResolveParameters:
-  * @conf              : Preset file to read from.
-  * @shader            : Shader passes handle.
-  *
-  * Resolves all shader parameters belonging to shaders.
-  *
-  * Returns: true (1) if successful, otherwise false (0).
-  **/
-  virtual bool ShaderPresetResolveParameters(config_file_t_ *conf, struct video_shader_ *shader) override;
-
-  /**
-  * FreePresetFile
-  * \shader shader Object to free.
-  *
-  * Frees all state related to shader
-  */
-  virtual void ShaderPresetFree(struct video_shader_* shader) override;
-
-private:
-  void GetAbsolutePassPath(video_shader_pass_& pass, char destPath[]);
-
-  // Base path of shader preset
-  std::string m_basePath;
+  config_file* ConfigFileNew(const char *path) override;
+  void ConfigFileFree(config_file *conf) override;
+  bool ShaderPresetRead(config_file *conf, video_shader &shader) override;
+  void ShaderPresetWrite(config_file *conf, const video_shader &shader) override;
+  //void ShaderPresetResolveRelative(video_shader &shader, const char *ref_path) override;
+  //bool ShaderPresetResolveCurrentParameters(config_file *conf, video_shader &shader) override;
+  bool ShaderPresetResolveParameters(config_file *conf, video_shader &shader) override;
+  void ShaderPresetFree(video_shader &shader) override;
 };

--- a/src/depends/gfx/video_shader_parse.c
+++ b/src/depends/gfx/video_shader_parse.c
@@ -134,7 +134,7 @@ static enum gfx_wrap_type wrap_str_to_mode(const char *wrap_mode)
  * Returns: true (1) if successful, otherwise false (0).
  **/
 static bool video_shader_parse_pass(config_file_t *conf,
-      struct video_shader_pass *pass, unsigned i)
+      struct rarch_video_shader_pass *pass, unsigned i)
 {
    char tmp_str[PATH_MAX_LENGTH];
    char tmp_path[PATH_MAX_LENGTH];
@@ -349,7 +349,7 @@ static bool video_shader_parse_pass(config_file_t *conf,
  * Returns: true (1) if successful, otherwise false (0).
  **/
 static bool video_shader_parse_textures(config_file_t *conf,
-      struct video_shader *shader)
+      struct rarch_video_shader *shader)
 {
    char textures[1024];
    const char *id       = NULL;
@@ -424,8 +424,8 @@ static bool video_shader_parse_textures(config_file_t *conf,
  *
  * Returns: handle to shader parameter if successful, otherwise NULL.
  **/
-static struct video_shader_parameter *video_shader_parse_find_parameter(
-      struct video_shader_parameter *params,
+static struct rarch_video_shader_parameter *video_shader_parse_find_parameter(
+      struct rarch_video_shader_parameter *params,
       unsigned num_params, const char *id)
 {
    unsigned i;
@@ -449,7 +449,7 @@ static struct video_shader_parameter *video_shader_parse_find_parameter(
  * Returns: true (1) if successful, otherwise false (0).
  **/
 bool video_shader_resolve_current_parameters(config_file_t *conf,
-      struct video_shader *shader)
+      struct rarch_video_shader *shader)
 {
    char parameters[4096];
    const char *id        = NULL;
@@ -468,7 +468,7 @@ bool video_shader_resolve_current_parameters(config_file_t *conf,
    for (id = strtok_r(parameters, ";", &save); id; 
          id = strtok_r(NULL, ";", &save))
    {
-      struct video_shader_parameter *parameter = (struct video_shader_parameter*)
+      struct rarch_video_shader_parameter *parameter = (struct rarch_video_shader_parameter*)
          video_shader_parse_find_parameter(shader->parameters, shader->num_parameters, id);
 
       if (!parameter)
@@ -493,10 +493,10 @@ bool video_shader_resolve_current_parameters(config_file_t *conf,
  * Returns: true (1) if successful, otherwise false (0).
  **/
 bool video_shader_resolve_parameters(config_file_t *conf,
-      struct video_shader *shader)
+      struct rarch_video_shader *shader)
 {
    unsigned i;
-   struct video_shader_parameter *param = &shader->parameters[0];
+   struct rarch_video_shader_parameter *param = &shader->parameters[0];
 
    shader->num_parameters = 0;
 
@@ -568,7 +568,7 @@ bool video_shader_resolve_parameters(config_file_t *conf,
  * Returns: true (1) if successful, otherwise false (0).
  **/
 static bool video_shader_parse_imports(config_file_t *conf,
-      struct video_shader *shader)
+      struct rarch_video_shader *shader)
 {
    char imports[1024];
    char tmp_str[PATH_MAX_LENGTH];
@@ -699,7 +699,7 @@ static bool video_shader_parse_imports(config_file_t *conf,
  *
  * Returns: true (1) if successful, otherwise false (0).
  **/
-bool video_shader_read_conf_cgp(config_file_t *conf, struct video_shader *shader)
+bool video_shader_read_conf_cgp(config_file_t *conf, struct rarch_video_shader *shader)
 {
    unsigned shaders, i;
 
@@ -883,7 +883,7 @@ static void shader_write_variable(config_file_t *conf,
  * textures, imports, etc) to disk. 
  **/
 void video_shader_write_conf_cgp(config_file_t *conf,
-      struct video_shader *shader)
+      struct rarch_video_shader *shader)
 {
    unsigned i;
 
@@ -895,7 +895,7 @@ void video_shader_write_conf_cgp(config_file_t *conf,
    {
       char key[64];
       char tmp[PATH_MAX_LENGTH];
-      const struct video_shader_pass *pass = &shader->pass[i];
+      const struct rarch_video_shader_pass *pass = &shader->pass[i];
 
       key[0] = '\0';
 
@@ -1062,7 +1062,7 @@ enum rarch_shader_type video_shader_parse_type(const char *path,
  * Resolves relative shader path (@ref_path) into absolute
  * shader paths.
  **/
-void video_shader_resolve_relative(struct video_shader *shader,
+void video_shader_resolve_relative(struct rarch_video_shader *shader,
       const char *ref_path)
 {
    unsigned i;

--- a/src/depends/gfx/video_shader_parse.h
+++ b/src/depends/gfx/video_shader_parse.h
@@ -88,7 +88,7 @@ struct gfx_fbo_scale
    bool valid;
 };
 
-struct video_shader_parameter
+struct rarch_video_shader_parameter
 {
    char id[64];
    char desc[64];
@@ -99,7 +99,7 @@ struct video_shader_parameter
    float step;
 };
 
-struct video_shader_pass
+struct rarch_video_shader_pass
 {
    struct
    {
@@ -119,7 +119,7 @@ struct video_shader_pass
    bool mipmap;
 };
 
-struct video_shader_lut
+struct rarch_video_shader_lut
 {
    char id[64];
    char path[PATH_MAX_LENGTH];
@@ -130,7 +130,7 @@ struct video_shader_lut
 
 /* This is pretty big, shouldn't be put on the stack.
  * Avoid lots of allocation for convenience. */
-struct video_shader
+struct rarch_video_shader
 {
    enum rarch_shader_type type;
 
@@ -138,12 +138,12 @@ struct video_shader
    char prefix[64];
 
    unsigned passes;
-   struct video_shader_pass pass[GFX_MAX_SHADERS];
+   struct rarch_video_shader_pass pass[GFX_MAX_SHADERS];
 
    unsigned luts;
-   struct video_shader_lut lut[GFX_MAX_TEXTURES];
+   struct rarch_video_shader_lut lut[GFX_MAX_TEXTURES];
 
-   struct video_shader_parameter parameters[GFX_MAX_PARAMETERS];
+   struct rarch_video_shader_parameter parameters[GFX_MAX_PARAMETERS];
    unsigned num_parameters;
 
    unsigned variables;
@@ -168,7 +168,7 @@ struct video_shader
  * Returns: true (1) if successful, otherwise false (0).
  **/
 bool video_shader_read_conf_cgp(config_file_t *conf,
-      struct video_shader *shader);
+      struct rarch_video_shader *shader);
 
 /** 
  * video_shader_write_conf_cgp:
@@ -179,7 +179,7 @@ bool video_shader_read_conf_cgp(config_file_t *conf,
  * textures, imports, etc) to disk. 
  **/
 void video_shader_write_conf_cgp(config_file_t *conf,
-      struct video_shader *shader);
+      struct rarch_video_shader *shader);
 
 /**
  * video_shader_resolve_relative:
@@ -189,7 +189,7 @@ void video_shader_write_conf_cgp(config_file_t *conf,
  * Resolves relative shader path (@ref_path) into absolute
  * shader paths.
  **/
-void video_shader_resolve_relative(struct video_shader *shader,
+void video_shader_resolve_relative(struct rarch_video_shader *shader,
       const char *ref_path);
 
 /** 
@@ -202,7 +202,7 @@ void video_shader_resolve_relative(struct video_shader *shader,
  * Returns: true (1) if successful, otherwise false (0).
  **/
 bool video_shader_resolve_current_parameters(config_file_t *conf,
-      struct video_shader *shader);
+      struct rarch_video_shader *shader);
 
 /** 
  * video_shader_resolve_parameters:
@@ -214,7 +214,7 @@ bool video_shader_resolve_current_parameters(config_file_t *conf,
  * Returns: true (1) if successful, otherwise false (0).
  **/
 bool video_shader_resolve_parameters(config_file_t *conf,
-      struct video_shader *shader);
+      struct rarch_video_shader *shader);
 
 /**
  * video_shader_parse_type:

--- a/src/utils/RarchTranslator.cpp
+++ b/src/utils/RarchTranslator.cpp
@@ -1,0 +1,404 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "RarchTranslator.h"
+
+#include <cstring>
+#include <malloc.h>
+
+SHADER_SCALE_TYPE CRarchTranslator::TranslateScaleType(enum gfx_scale_type type)
+{
+  switch (type)
+  {
+  case RARCH_SCALE_INPUT:
+    return SHADER_SCALE_TYPE_INPUT;
+  case RARCH_SCALE_ABSOLUTE:
+    return SHADER_SCALE_TYPE_ABSOLUTE;
+  case RARCH_SCALE_VIEWPORT:
+    return SHADER_SCALE_TYPE_VIEWPORT;
+  default:
+    break;
+  }
+
+  return SHADER_SCALE_TYPE_INPUT;
+}
+
+enum gfx_scale_type CRarchTranslator::TranslateScaleType(SHADER_SCALE_TYPE type)
+{
+  switch (type)
+  {
+  case SHADER_SCALE_TYPE_INPUT:
+    return RARCH_SCALE_INPUT;
+  case SHADER_SCALE_TYPE_ABSOLUTE:
+    return RARCH_SCALE_ABSOLUTE;
+  case SHADER_SCALE_TYPE_VIEWPORT:
+    return RARCH_SCALE_VIEWPORT;
+  default:
+    break;
+  }
+
+  return RARCH_SCALE_INPUT;
+}
+
+SHADER_FILTER_TYPE CRarchTranslator::TranslateFilterType(unsigned int type)
+{
+  switch (type)
+  {
+  case RARCH_FILTER_UNSPEC:
+    return SHADER_FILTER_TYPE_UNSPEC;
+  case RARCH_FILTER_LINEAR:
+    return SHADER_FILTER_TYPE_LINEAR;
+  case RARCH_FILTER_NEAREST:
+    return SHADER_FILTER_TYPE_NEAREST;
+  default:
+    break;
+  }
+
+  return SHADER_FILTER_TYPE_UNSPEC;
+}
+
+unsigned int CRarchTranslator::TranslateFilterType(SHADER_FILTER_TYPE type)
+{
+  switch (type)
+  {
+  case SHADER_FILTER_TYPE_UNSPEC:
+    return RARCH_FILTER_UNSPEC;
+  case SHADER_FILTER_TYPE_LINEAR:
+    return RARCH_FILTER_LINEAR;
+  case SHADER_FILTER_TYPE_NEAREST:
+    return RARCH_FILTER_NEAREST;
+  default:
+    break;
+  }
+
+  return RARCH_FILTER_UNSPEC;
+}
+
+SHADER_WRAP_TYPE CRarchTranslator::TranslateWrapType(enum gfx_wrap_type type)
+{
+  switch (type)
+  {
+  case RARCH_WRAP_BORDER:
+    return SHADER_WRAP_TYPE_BORDER;
+  case RARCH_WRAP_EDGE:
+    return SHADER_WRAP_TYPE_EDGE;
+  case RARCH_WRAP_REPEAT:
+    return SHADER_WRAP_TYPE_REPEAT;
+  case RARCH_WRAP_MIRRORED_REPEAT:
+    return SHADER_WRAP_TYPE_MIRRORED_REPEAT;
+  default:
+    break;
+  }
+
+  return SHADER_WRAP_TYPE_BORDER;
+}
+
+enum gfx_wrap_type CRarchTranslator::TranslateWrapType(SHADER_WRAP_TYPE type)
+{
+  switch (type)
+  {
+  case SHADER_WRAP_TYPE_BORDER:
+    return RARCH_WRAP_BORDER;
+  case SHADER_WRAP_TYPE_EDGE:
+    return RARCH_WRAP_EDGE;
+  case SHADER_WRAP_TYPE_REPEAT:
+    return RARCH_WRAP_REPEAT;
+  case SHADER_WRAP_TYPE_MIRRORED_REPEAT:
+    return RARCH_WRAP_MIRRORED_REPEAT;
+  default:
+    break;
+  }
+
+  return RARCH_WRAP_DEFAULT;
+}
+
+void CRarchTranslator::TranslateShaderPass(const rarch_video_shader_pass &rarch_pass, video_shader_pass &pass)
+{
+  pass.source_path = nullptr;
+  if (rarch_pass.source.path != nullptr)
+  {
+    const unsigned int source_path_len = std::strlen(rarch_pass.source.path);
+    if (source_path_len > 0)
+    {
+      pass.source_path = new char[source_path_len];
+      std::strcpy(pass.source_path, rarch_pass.source.path);
+    }
+  }
+
+  pass.vertex_source = nullptr;
+  if (rarch_pass.source.string.vertex != nullptr)
+  {
+    const unsigned int vertex_source_len = std::strlen(rarch_pass.source.string.vertex);
+    if (vertex_source_len > 0)
+    {
+      pass.vertex_source = new char[vertex_source_len];
+      std::strcpy(pass.vertex_source, rarch_pass.source.string.vertex);
+    }
+  }
+
+  pass.fragment_source = nullptr;
+  if (rarch_pass.source.string.fragment != nullptr)
+  {
+    const unsigned int fragment_source_len = std::strlen(rarch_pass.source.string.fragment);
+    if (fragment_source_len > 0)
+    {
+      pass.fragment_source = new char[fragment_source_len];
+      std::strcpy(pass.fragment_source, rarch_pass.source.string.fragment);
+    }
+  }
+
+  auto &fbo = pass.fbo;
+  auto &rarch_fbo = rarch_pass.fbo;
+
+  fbo.fp_fbo = rarch_fbo.fp_fbo;
+  fbo.srgb_fbo = rarch_fbo.srgb_fbo;
+  fbo.scale_x.type = TranslateScaleType(rarch_fbo.type_x);
+  fbo.scale_y.type = TranslateScaleType(rarch_fbo.type_y);
+  switch (fbo.scale_x.type)
+  {
+  case SHADER_SCALE_TYPE_ABSOLUTE:
+    fbo.scale_x.abs = rarch_fbo.abs_x;
+    break;
+  default:
+    fbo.scale_x.scale = rarch_fbo.scale_x;
+    break;
+  }
+  switch (fbo.scale_y.type)
+  {
+  case SHADER_SCALE_TYPE_ABSOLUTE:
+    fbo.scale_y.abs = rarch_fbo.abs_y;
+    break;
+  default:
+    fbo.scale_y.scale = rarch_fbo.scale_y;
+    break;
+  }
+
+  pass.filter = TranslateFilterType(rarch_pass.filter);
+  pass.wrap = TranslateWrapType(rarch_pass.wrap);
+  pass.frame_count_mod = rarch_pass.frame_count_mod;
+  pass.mipmap = rarch_pass.mipmap;
+}
+
+void CRarchTranslator::TranslateShaderPass(const video_shader_pass &pass, rarch_video_shader_pass &rarch_pass)
+{
+  rarch_pass.source.path[0] = '\0';
+  if (pass.source_path != nullptr)
+    std::strcpy(rarch_pass.source.path, pass.source_path);
+
+  rarch_pass.source.string.vertex = nullptr;
+  if (pass.vertex_source != nullptr)
+  {
+    unsigned int vertex_len = std::strlen(pass.vertex_source);
+    rarch_pass.source.string.vertex = static_cast<char*>(malloc(vertex_len));
+    std::strcpy(rarch_pass.source.string.vertex, pass.vertex_source);
+  }
+
+  rarch_pass.source.string.fragment = nullptr;
+  if (pass.fragment_source != nullptr)
+  {
+    unsigned int fragment_len = std::strlen(pass.fragment_source);
+    rarch_pass.source.string.fragment = static_cast<char*>(malloc(fragment_len));
+    std::strcpy(rarch_pass.source.string.fragment, pass.fragment_source);
+  }
+
+  rarch_pass.alias[0] = '\0';
+
+  auto &rarch_fbo = rarch_pass.fbo;
+  auto &fbo = pass.fbo;
+
+  rarch_fbo.fp_fbo = fbo.fp_fbo;
+  rarch_fbo.srgb_fbo = fbo.srgb_fbo;
+  rarch_fbo.type_x = TranslateScaleType(fbo.scale_x.type);
+  rarch_fbo.type_y = TranslateScaleType(fbo.scale_y.type);
+  switch (rarch_fbo.type_x)
+  {
+  case RARCH_SCALE_ABSOLUTE:
+    rarch_fbo.abs_x = fbo.scale_x.abs;
+    break;
+  default:
+    rarch_fbo.scale_x = fbo.scale_x.scale;
+    break;
+  }
+  switch (fbo.scale_y.type)
+  {
+  case RARCH_SCALE_ABSOLUTE:
+    rarch_fbo.abs_y = fbo.scale_y.abs;
+    break;
+  default:
+    rarch_fbo.scale_y = fbo.scale_y.scale;
+    break;
+  }
+
+  rarch_pass.filter = TranslateFilterType(pass.filter);
+  rarch_pass.wrap = TranslateWrapType(pass.wrap);
+  rarch_pass.frame_count_mod = pass.frame_count_mod;
+  rarch_pass.mipmap = pass.mipmap;
+}
+
+void CRarchTranslator::TranslateShaderLut(const rarch_video_shader_lut &rarch_lut, video_shader_lut &lut)
+{
+  lut.id = nullptr;
+  unsigned int id_len = std::strlen(rarch_lut.id);
+  if (id_len > 0)
+  {
+    lut.id = new char[id_len];
+    std::strcpy(lut.id, rarch_lut.id);
+  }
+
+  lut.path = nullptr;
+  unsigned int path_len = std::strlen(rarch_lut.path);
+  if (path_len > 0)
+  {
+    lut.path = new char[path_len];
+    std::strcpy(lut.path, rarch_lut.path);
+  }
+
+  lut.filter = TranslateFilterType(rarch_lut.filter);
+  lut.wrap = TranslateWrapType(rarch_lut.wrap);
+  lut.mipmap = rarch_lut.mipmap;
+}
+
+void CRarchTranslator::TranslateShaderLut(const video_shader_lut &lut, rarch_video_shader_lut &rarch_lut)
+{
+  rarch_lut.id[0] = '\0';
+  if (lut.id != nullptr)
+    std::strcpy(rarch_lut.id, lut.id);
+
+  rarch_lut.path[0] = '\0';
+  if (lut.path != nullptr)
+    std::strcpy(rarch_lut.path, lut.path);
+
+  rarch_lut.filter = TranslateFilterType(lut.filter);
+  rarch_lut.wrap = TranslateWrapType(lut.wrap);
+  rarch_lut.mipmap = lut.mipmap;
+}
+
+void CRarchTranslator::TranslateShaderParameter(const rarch_video_shader_parameter &rarch_param, video_shader_parameter &param)
+{
+  param.id = nullptr;
+  unsigned int id_len = std::strlen(rarch_param.id);
+  if (id_len > 0)
+  {
+    param.id = new char[id_len];
+    std::strcpy(param.id, rarch_param.id);
+  }
+
+  param.desc = nullptr;
+  unsigned int desc_len = std::strlen(rarch_param.desc);
+  if (desc_len > 0)
+  {
+    param.desc = new char[desc_len];
+    std::strcpy(param.desc, rarch_param.desc);
+  }
+
+  param.current = rarch_param.current;
+  param.minimum = rarch_param.minimum;
+  param.initial = rarch_param.initial;
+  param.maximum = rarch_param.maximum;
+  param.step = rarch_param.step;
+}
+
+void CRarchTranslator::TranslateShaderParameter(const video_shader_parameter &param, rarch_video_shader_parameter &rarch_param)
+{
+  rarch_param.id[0] = '\0';
+  if (param.id != nullptr)
+    std::strcpy(rarch_param.id, param.id);
+
+  rarch_param.desc[0] = '\0';
+  if (param.desc != nullptr)
+    std::strcpy(rarch_param.desc, param.desc);
+
+  rarch_param.current = param.current;
+  rarch_param.minimum = param.minimum;
+  rarch_param.initial = param.initial;
+  rarch_param.maximum = param.maximum;
+  rarch_param.step = param.step;
+}
+
+void CRarchTranslator::TranslateShader(const rarch_video_shader &rarch_shader, video_shader &shader)
+{
+  shader.pass_count = rarch_shader.passes;
+  shader.passes = nullptr;
+  if (shader.pass_count > 0)
+  {
+    shader.passes = new video_shader_pass[shader.pass_count];
+    for (unsigned int i = 0; i < shader.pass_count; i++)
+      TranslateShaderPass(rarch_shader.pass[i], shader.passes[i]);
+  }
+
+  shader.lut_count = rarch_shader.luts;
+  shader.luts = nullptr;
+  if (shader.lut_count > 0)
+  {
+    shader.luts = new video_shader_lut[shader.lut_count];
+    for (unsigned int i = 0; i < shader.lut_count; i++)
+      TranslateShaderLut(rarch_shader.lut[i], shader.luts[i]);
+  }
+
+  shader.parameter_count = rarch_shader.num_parameters;
+  shader.parameters = nullptr;
+  if (shader.parameter_count > 0)
+  {
+    shader.parameters = new video_shader_parameter[shader.parameter_count];
+    for (unsigned int i = 0; i < shader.parameter_count; i++)
+      TranslateShaderParameter(rarch_shader.parameters[i], shader.parameters[i]);
+  }
+}
+
+void CRarchTranslator::TranslateShader(const video_shader &shader, rarch_video_shader &rarch_shader)
+{
+  rarch_shader.type = RARCH_SHADER_NONE; //! @todo
+
+  rarch_shader.modern = false;
+  rarch_shader.prefix[0] = '\0';
+
+  rarch_shader.passes = shader.pass_count;
+  for (unsigned int i = 0; i < rarch_shader.passes; i++)
+    TranslateShaderPass(shader.passes[i], rarch_shader.pass[i]);
+
+  rarch_shader.luts = shader.lut_count;
+  for (unsigned int i = 0; i < rarch_shader.luts; i++)
+    TranslateShaderLut(shader.luts[i], rarch_shader.lut[i]);
+
+  rarch_shader.num_parameters = shader.parameter_count;
+  for (unsigned int i = 0; i < rarch_shader.num_parameters; i++)
+    TranslateShaderParameter(shader.parameters[i], rarch_shader.parameters[i]);
+
+  rarch_shader.variables = 0;
+  rarch_shader.script_path[0] = '\0';
+  rarch_shader.script = nullptr;
+  rarch_shader.script_class[0] = '\0';
+  rarch_shader.feedback_pass = -1;
+}
+
+void CRarchTranslator::FreeShader(rarch_video_shader &rarch_shader)
+{
+  for (unsigned int i = 0; i < rarch_shader.passes; i++)
+  {
+    auto &rarch_pass = rarch_shader.pass[i];
+
+    free(rarch_pass.source.string.vertex);
+    if (rarch_pass.source.string.vertex != rarch_pass.source.string.fragment)
+      free(rarch_pass.source.string.fragment);
+
+    rarch_pass.source.string.vertex = nullptr;
+    rarch_pass.source.string.fragment = nullptr;
+  }
+}

--- a/src/utils/RarchTranslator.h
+++ b/src/utils/RarchTranslator.h
@@ -1,0 +1,52 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "gfx/video_shader_parse.h"
+
+#include <kodi/addon-instance/ShaderPreset.h>
+
+class CRarchTranslator
+{
+public:
+  static SHADER_SCALE_TYPE TranslateScaleType(enum gfx_scale_type type);
+  static enum gfx_scale_type TranslateScaleType(SHADER_SCALE_TYPE type);
+
+  static SHADER_FILTER_TYPE TranslateFilterType(unsigned int type);
+  static unsigned int TranslateFilterType(SHADER_FILTER_TYPE type);
+
+  static SHADER_WRAP_TYPE TranslateWrapType(enum gfx_wrap_type type);
+  static enum gfx_wrap_type TranslateWrapType(SHADER_WRAP_TYPE type);
+
+  static void TranslateShaderPass(const rarch_video_shader_pass &rarch_pass, video_shader_pass &pass);
+  static void TranslateShaderPass(const video_shader_pass &pass, rarch_video_shader_pass &rarch_pass);
+
+  static void TranslateShaderLut(const rarch_video_shader_lut &rarch_lut, video_shader_lut &lut);
+  static void TranslateShaderLut(const video_shader_lut &lut, rarch_video_shader_lut &rarch_lut);
+
+  static void TranslateShaderParameter(const rarch_video_shader_parameter &rarch_param, video_shader_parameter &param);
+  static void TranslateShaderParameter(const video_shader_parameter &param, rarch_video_shader_parameter &rarch_param);
+
+  static void TranslateShader(const rarch_video_shader &rarch_shader, video_shader &shader);
+  static void TranslateShader(const video_shader &shader, rarch_video_shader &rarch_shader);
+
+  //! @todo
+  static void FreeShader(rarch_video_shader &rarch_shader);
+};


### PR DESCRIPTION
This fixes compilation after https://github.com/VelocityRa/xbmc/pull/6. That PR updates the central data structure. Instead of modifying RetroArch code, I kept the existing struct and translated between the two structs. This has pretty serious performance impacts, but it's better to maintain correctness in this step. Later, the RetroArch code can be modified to use the new struct.

TODO: Convert relative paths to absolute paths