### PR TITLE
Update to Shader API v0.0.4: Translate relative paths

### DIFF
--- a/game.shader.presets/addon.xml.in
+++ b/game.shader.presets/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="game.shader.presets"
-  version="0.0.3"
+  version="0.0.4"
   name="Shader Preset Support"
   provider-name="Team-Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/addon.h
+++ b/src/addon.h
@@ -38,12 +38,12 @@ public:
   virtual ADDON_STATUS SetSetting(const std::string& settingName, const kodi::CSettingValue& settingValue) override;
 
   // CInstanceShaderPreset overrides
-  config_file* ConfigFileNew(const char *path) override;
-  void ConfigFileFree(config_file *conf) override;
-  bool ShaderPresetRead(config_file *conf, video_shader &shader) override;
-  void ShaderPresetWrite(config_file *conf, const video_shader &shader) override;
+  preset_file PresetFileNew(const char *path) override;
+  void PresetFileFree(preset_file file) override;
+  bool ShaderPresetRead(preset_file file, video_shader &shader) override;
+  void ShaderPresetWrite(preset_file file, const video_shader &shader) override;
   //void ShaderPresetResolveRelative(video_shader &shader, const char *ref_path) override;
-  //bool ShaderPresetResolveCurrentParameters(config_file *conf, video_shader &shader) override;
-  bool ShaderPresetResolveParameters(config_file *conf, video_shader &shader) override;
+  //bool ShaderPresetResolveCurrentParameters(preset_file file, video_shader &shader) override;
+  bool ShaderPresetResolveParameters(preset_file file, video_shader &shader) override;
   void ShaderPresetFree(video_shader &shader) override;
 };

--- a/src/utils/RarchTranslator.h
+++ b/src/utils/RarchTranslator.h
@@ -23,6 +23,8 @@
 
 #include <kodi/addon-instance/ShaderPreset.h>
 
+#include <string>
+
 class CRarchTranslator
 {
 public:
@@ -35,17 +37,20 @@ public:
   static SHADER_WRAP_TYPE TranslateWrapType(enum gfx_wrap_type type);
   static enum gfx_wrap_type TranslateWrapType(SHADER_WRAP_TYPE type);
 
-  static void TranslateShaderPass(const rarch_video_shader_pass &rarch_pass, video_shader_pass &pass);
-  static void TranslateShaderPass(const video_shader_pass &pass, rarch_video_shader_pass &rarch_pass);
+  static void TranslateShaderPass(const rarch_video_shader_pass &rarch_pass, video_shader_pass &pass, const std::string &configPath);
+  static void TranslateShaderPass(const video_shader_pass &pass, rarch_video_shader_pass &rarch_pass, const std::string &configPath);
 
-  static void TranslateShaderLut(const rarch_video_shader_lut &rarch_lut, video_shader_lut &lut);
-  static void TranslateShaderLut(const video_shader_lut &lut, rarch_video_shader_lut &rarch_lut);
+  static void TranslateShaderLut(const rarch_video_shader_lut &rarch_lut, video_shader_lut &lut, const std::string &configPath);
+  static void TranslateShaderLut(const video_shader_lut &lut, rarch_video_shader_lut &rarch_lut, const std::string &configPath);
 
   static void TranslateShaderParameter(const rarch_video_shader_parameter &rarch_param, video_shader_parameter &param);
   static void TranslateShaderParameter(const video_shader_parameter &param, rarch_video_shader_parameter &rarch_param);
 
-  static void TranslateShader(const rarch_video_shader &rarch_shader, video_shader &shader);
-  static void TranslateShader(const video_shader &shader, rarch_video_shader &rarch_shader);
+  static void TranslateShader(const rarch_video_shader &rarch_shader, video_shader &shader, const std::string &configPath);
+  static void TranslateShader(const video_shader &shader, rarch_video_shader &rarch_shader, const std::string &configPath);
+
+  static void TranslateRelativePath(char *absPath, const char *relPath, const std::string &configPath);
+  static void TranslateAbsPath(char *relPath, const char *absPath, const std::string &configPath);
 
   //! @todo
   static void FreeShader(rarch_video_shader &rarch_shader);

--- a/src/utils/StringUtils.cpp
+++ b/src/utils/StringUtils.cpp
@@ -193,3 +193,18 @@ void StringUtils::Tokenize(const std::string& input, std::vector<std::string>& t
       dataPos = input.find_first_not_of(delimiters, nextDelimPos);
    }
 }
+
+int StringUtils::Replace(std::string &str, char oldChar, char newChar)
+{
+  int replacedChars = 0;
+  for (std::string::iterator it = str.begin(); it != str.end(); ++it)
+  {
+    if (*it == oldChar)
+    {
+      *it = newChar;
+      replacedChars++;
+    }
+  }
+
+  return replacedChars;
+}

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -97,5 +97,7 @@ namespace SHADER
           result.erase(result.size() - delimiter.size());
        return result;
     }
+
+    static int Replace(std::string &str, char oldChar, char newChar);
   };
 }

--- a/src/utils/URIUtils.h
+++ b/src/utils/URIUtils.h
@@ -27,9 +27,21 @@ class CURL;
 class URIUtils
 {
 public:
-  URIUtils(void);
-  virtual ~URIUtils(void);
-/**
+  static bool IsDOSPath(const std::string &path);
+
+  static bool IsAbsPath(const std::string &path);
+
+  static std::string GetDirectory(const std::string &strFilePath);
+
+  static std::string AddFileToFolder(const std::string& strFolder, const std::string& strFile);
+
+  static void AddSlashAtEnd(std::string& strFolder);
+
+  static bool HasSlashAtEnd(const std::string& strFile);
+
+  static std::string CanonicalizePath(const std::string& path);
+
+  /**
    * Convert path to form without duplicated slashes and without relative directories
    * Strip duplicated slashes
    * Resolve and remove relative directories ("/../" and "/./")
@@ -40,6 +52,6 @@ public:
    * @param slashCharacter character to use as directory delimiter
    * @return transformed path
    */
-  static std::string CanonicalizePath(const std::string& path, const char slashCharacter = '\\');
+  static std::string CanonicalizePath(const std::string& path, const char slashCharacter);
 };
 


### PR DESCRIPTION
This change will translate relative paths to absolute paths.

When translating in the other direction, absolute paths stay absolute. If we want to write .cgp files, and we want to use relative paths, then we'll have to implement the remaining TODO in this PR's code.

Requires https://github.com/VelocityRa/xbmc/pull/9