### PR TITLE
Reorder filters in ShaderPresetsDefault.xml

### DIFF
--- a/game.shader.presets/resources/ShaderPresetsDefault.xml
+++ b/game.shader.presets/resources/ShaderPresetsDefault.xml
@@ -1,125 +1,8 @@
 <?xml version="1.0" ?>
 <presets>
     <preset>
-        <path>libretro/hlsl/eagle/super-eagle.cgp</path>
-        <!-- Super Eagle -->
-        <name>30024</name>
-        <!-- Scaling Shader -->
-        <category>30018</category>
-        <!-- Reduces pixelation by smoothing and rounding edges. Uses the Super Eagle algorithm (by Kreed) to scale, by detecting edges and interpolating pixels along them. Does more blending than other scaling algorithms. -->
-        <description>30025</description>
-    </preset>
-    <preset>
-        <path>libretro/hlsl/xbr/xbr-lv2-fast.cgp</path>
-        <!-- xBR-lv2 (fast) -->
-        <name>30019</name>
-        <!-- Scaling Shader -->
-        <category>30018</category>
-        <!-- Attempts to reduce pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm to scale. Simplified lvl2 implementation. Detects 4 edges. Much faster than the standard version, though it sacrifices some quality. -->
-        <description>30020</description>
-    </preset>
-    <preset>
-        <path>libretro/hlsl/xbr/xbr-lv3.cgp</path>
-        <!-- xBR-lv3 -->
-        <name>30037</name>
-        <!-- Scaling Shader -->
-        <category>30018</category>
-        <!-- Reduces pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm. Detects 6 edges, which shows as better rounded objects on screen. The interpolation blends pixel colors, so the final image is smoother than noblend versions. -->
-        <description>30039</description>
-    </preset>
-    <preset>
-        <path>libretro/hlsl/xbr/xbr-lv3-noblend.cgp</path>
-        <!-- xBR-lv3 No Blend -->
-        <name>30038</name>
-        <!-- Scaling Shader -->
-        <category>30018</category>
-        <!-- Reduces pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm. Detects 6 edges, which shows as better rounded objects on screen. The interpolation doesn't blend pixel colors. -->
-        <description>30040</description>
-    </preset>
-    <preset>
-        <path>libretro/hlsl/handheld/lcd3x.cgp</path>
-        <!-- LCD3x -->
-        <name>30033</name>
-        <!-- Scaling Shader -->
-        <category>30018</category>
-        <!-- LCD3x is an image filter by gigaherz that simulates the aspect of an LCD screen while at the same time increasing the size of the source image. -->
-        <description>30034</description>
-    </preset>
-    <preset>
-        <path>libretro/hlsl/handheld/lcd-grid-v2-gba-color.cgp</path>
-        <!-- GBA Colors -->
-        <name>30026</name>
-        <!-- Handheld -->
-        <category>30030</category>
-        <!-- No description. -->
-        <description>30031</description>
-    </preset>
-    <preset>
-        <path>libretro/hlsl/handheld/lcd-grid-v2-nds-color.cgp</path>
-        <!-- NDS Colors -->
-        <name>30027</name>
-        <!-- Handheld -->
-        <category>30030</category>
-        <!-- No description. -->
-        <description>30031</description>
-    </preset>
-    <preset>
-        <path>libretro/hlsl/handheld/lcd-grid-v2-psp-color.cgp</path>
-        <!-- PSP Colors -->
-        <name>30028</name>
-        <!-- Handheld -->
-        <category>30030</category>
-        <!-- No description. -->
-        <description>30031</description>
-    </preset>
-    <preset>
-        <path>libretro/hlsl/handheld/lcd-grid-v2-vba-color.cgp</path>
-        <!-- VBA Colors -->
-        <name>30029</name>
-        <!-- Handheld -->
-        <category>30030</category>
-        <!-- No description. -->
-        <description>30031</description>
-    </preset>
-    <preset>
-        <path>libretro/hlsl/cgp/gameboy-screen-grid.cgp</path>
-        <!-- Game Boy Screen -->
-        <name>30000</name>
-        <!-- Game Boy -->
-        <category>30001</category>
-        <!-- Replicates the dot matrix screen of a Game Boy, complete with the ghosting problems to reproduce certain visual effects. -->
-        <description>30002</description>
-    </preset>
-    <preset>
-        <path>libretro/hlsl/crt/4xbr-hybrid-crt-b.cgp</path>
-        <!-- 4xbr Hybrid -->
-        <name>30003</name>
-        <!-- CRT Display -->
-        <category>30004</category>
-        <!-- Emulates a CRT display. Basic. Features scan-lines, color correction, gamma correction and sharpening. -->
-        <description>30005</description>
-    </preset>
-<!--    <preset> -->
-<!--        <path>libretro/hlsl/crt/crt-hyllian-multipass.cgp</path> -->
-        <!-- Hylian Multipass -->
-<!--        <name>30006</name> -->
-        <!-- CRT Display -->
-<!--        <category>30004</category> -->
-        <!-- Emulates a CRT display. Advanced and fast. Aims only for picture quality, so it avoids effects that degrade the image. Features scan-lines, color correction, gamma correction, sharpening, CRT phosphor and CRT beam effects. -->
-<!--        <description>30007</description> -->
-<!--    </preset> -->
-<!--    <preset> -->
-<!--        <path>libretro/hlsl/cgp/crt-royale-kurozumi.cgp</path> -->
-        <!-- CRT Display (Royale) -->
-<!--        <name>30008</name> -->
-        <!-- CRT Display -->
-<!--        <category>30004</category> -->
-        <!-- Emulates a CRT display. Highly advanced multi-pass shader. Resource intensive. Features scan-lines, color correction, gamma correction, sharpening, CRT phosphor emulation, halation, refractive diffusion, curvature and anti-aliasing. -->
-<!--        <description>30009</description> -->
-<!--    </preset> -->
-    <preset>
         <path>libretro/hlsl/ntsc/ntsc.cgp</path>
-        <!-- NTSC Filter -->
+        <!-- Television -->
         <name>30010</name>
         <!-- NTSC -->
         <category>30011</category>
@@ -128,38 +11,155 @@
     </preset>
     <preset>
         <path>libretro/hlsl/cgp/tvout/tvout+ntsc-256px-composite.cgp</path>
-        <!-- NTSC 256px Composite -->
+        <!-- TV-out -->
         <name>30013</name>
-        <!-- NTSC/TV-out -->
+        <!-- NTSC 256px Composite -->
         <category>30014</category>
         <!-- Replicates the analog signals that the consoles output to the TV. 256px downscale resolution. Emulates composite connector. Features color distortion, blurring, NTSC color artifacts. -->
         <description>30016</description>
     </preset>
     <preset>
         <path>libretro/hlsl/cgp/tvout/tvout+ntsc-256px-svideo.cgp</path>
+        <!-- TV-out -->
+        <name>30013</name>
         <!-- NTSC 256px S-video -->
-        <name>30035</name>
-        <!-- NTSC/TV-out -->
-        <category>30014</category>
+        <category>30035</category>
         <!-- Replicates the analog signals that the consoles output to the TV. 256px downscale resolution. Emulates S-Video connector. Features color distortion, blurring, NTSC color artifacts. -->
         <description>30015</description>
     </preset>
     <preset>
         <path>libretro/hlsl/cgp/tvout/tvout+ntsc-320px-svideo.cgp</path>
+        <!-- TV-out -->
+        <name>30013</name>
         <!-- NTSC 320px S-video -->
-        <name>30036</name>
-        <!-- NTSC/TV-out -->
-        <category>30014</category>
+        <category>30036</category>
         <!-- Replicates the analog signals that the consoles output to the TV. 320px downscale resolution. Emulates S-Video connector. Features color distortion, blurring, NTSC color artifacts. -->
         <description>30017</description>
     </preset>
+    <preset>
+        <path>libretro/hlsl/crt/4xbr-hybrid-crt-b.cgp</path>
+        <!-- CRT Display -->
+        <name>30004</name>
+        <!-- 4xbr Hybrid -->
+        <category>30003</category>
+        <!-- Emulates a CRT display. Basic. Features scan-lines, color correction, gamma correction and sharpening. -->
+        <description>30005</description>
+    </preset>
+<!--    <preset> -->
+<!--        <path>libretro/hlsl/crt/crt-hyllian-multipass.cgp</path> -->
+        <!-- CRT Display -->
+<!--        <name>30004</name> -->
+        <!-- Hylian Multipass -->
+<!--        <category>30006</category> -->
+        <!-- Emulates a CRT display. Advanced and fast. Aims only for picture quality, so it avoids effects that degrade the image. Features scan-lines, color correction, gamma correction, sharpening, CRT phosphor and CRT beam effects. -->
+<!--        <description>30007</description> -->
+<!--    </preset> -->
+<!--    <preset> -->
+<!--        <path>libretro/hlsl/cgp/crt-royale-kurozumi.cgp</path> -->
+        <!-- CRT Display -->
+<!--        <name>30004</name> -->
+        <!-- Royale -->
+<!--        <category>30008</category> -->
+        <!-- Emulates a CRT display. Highly advanced multi-pass shader. Resource intensive. Features scan-lines, color correction, gamma correction, sharpening, CRT phosphor emulation, halation, refractive diffusion, curvature and anti-aliasing. -->
+<!--        <description>30009</description> -->
+<!--    </preset> -->
+    <preset>
+        <path>libretro/hlsl/handheld/lcd3x.cgp</path>
+        <!-- LCD Screen -->
+        <name>30032</name>
+        <!-- LCD3x -->
+        <category>30033</category>
+        <!-- LCD3x is an image filter by gigaherz that simulates the aspect of an LCD screen while at the same time increasing the size of the source image. -->
+        <description>30034</description>
+    </preset>
+    <preset>
+        <path>libretro/hlsl/cgp/gameboy-screen-grid.cgp</path>
+        <!-- LCD Screen -->
+        <name>30032</name>
+        <!-- Game Boy -->
+        <category>30001</category>
+        <!-- Replicates the dot matrix screen of a Game Boy, complete with the ghosting problems to reproduce certain visual effects. -->
+        <description>30002</description>
+    </preset>
+    <preset>
+        <path>libretro/hlsl/eagle/super-eagle.cgp</path>
+        <!-- Scaling Shader -->
+        <name>30018</name>
+        <!-- Super Eagle -->
+        <category>30024</category>
+        <!-- Attempts to reduce pixelation by smoothing and rounding edges. Uses the Super Eagle algorithm (by Kreed) to scale, by detecting edges and interpolating pixels along them. Does more blending than other scaling algorithms. -->
+        <description>30025</description>
+    </preset>
+    <preset>
+        <path>libretro/hlsl/xbr/xbr-lv2-fast.cgp</path>
+        <!-- Scaling Shader -->
+        <name>30018</name>
+        <!-- xBR-lv2 -->
+        <category>30019</category>
+        <!-- Attempts to reduce pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm to scale, by detecting edges and interpolating pixels along them. -->
+        <description>30020</description>
+    </preset>
+    <preset>
+        <path>libretro/hlsl/xbr/xbr-lv3.cgp</path>
+        <!-- Scaling Shader -->
+        <name>30018</name>
+        <!-- xBR-lv3 -->
+        <category>30037</category>
+        <!-- Reduces pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm. Detects 6 edges, which shows as better rounded objects on screen. The interpolation blends pixel colors, so the final image is smoother than noblend versions. -->
+        <description>30039</description>
+    </preset>
+    <preset>
+        <path>libretro/hlsl/xbr/xbr-lv3-noblend.cgp</path>
+        <!-- Scaling Shader -->
+        <name>30018</name>
+        <!-- xBR-lv3 No Blend -->
+        <category>30038</category>
+        <!-- Reduces pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm. Detects 6 edges, which shows as better rounded objects on screen. The interpolation doesn't blend pixel colors. -->
+        <description>30040</description>
+    </preset>
 <!--    <preset> -->
 <!--        <path>libretro/hlsl/xbr/xbr-mlv4-multipass.cgp</path> -->
-        <!-- xBR-mlv4 -->
-<!--        <name>30021</name> -->
         <!-- Scaling Shader -->
-<!--        <category>30018</category> -->
+<!--        <name>30018</name> -->
+        <!-- xBR-mlv4 -->
+<!--        <category>30021</category> -->
         <!-- Attempts to reduce pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm to scale, by detecting edges and interpolating pixels along them. Latest evolution of the standard xBR algorithm. The interpolation blends pixel colors, so that the final image is smoother than the other versions. -->
 <!--        <description>30022</description> -->
 <!--    </preset> -->
+    <preset>
+        <path>libretro/hlsl/handheld/lcd-grid-v2-vba-color.cgp</path>
+        <!-- Handheld -->
+        <name>30030</name>
+        <!-- VBA Colors -->
+        <category>30029</category>
+        <!-- No description. -->
+        <description>30031</description>
+    </preset>
+    <preset>
+        <path>libretro/hlsl/handheld/lcd-grid-v2-gba-color.cgp</path>
+        <!-- Handheld -->
+        <name>30030</name>
+        <!-- GBA Colors -->
+        <category>30026</category>
+        <!-- No description. -->
+        <description>30031</description>
+    </preset>
+    <preset>
+        <path>libretro/hlsl/handheld/lcd-grid-v2-nds-color.cgp</path>
+        <!-- Handheld -->
+        <name>30030</name>
+        <!-- NDS Colors -->
+        <category>30027</category>
+        <!-- No description. -->
+        <description>30031</description>
+    </preset>
+    <preset>
+        <path>libretro/hlsl/handheld/lcd-grid-v2-psp-color.cgp</path>
+        <!-- Handheld -->
+        <name>30030</name>
+        <!-- PSP Colors -->
+        <category>30028</category>
+        <!-- No description. -->
+        <description>30031</description>
+    </preset>
 </presets>

--- a/game.shader.presets/resources/language/resource.language.en_gb/strings.po
+++ b/game.shader.presets/resources/language/resource.language.en_gb/strings.po
@@ -16,9 +16,7 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgctxt "#30000"
-msgid "Game Boy Screen"
-msgstr ""
+#empty string with id 30000
 
 msgctxt "#30001"
 msgid "Game Boy"
@@ -49,7 +47,7 @@ msgid "Emulates a CRT display. Advanced and fast. Aims only for picture quality,
 msgstr ""
 
 msgctxt "#30008"
-msgid "CRT Display (Royale)"
+msgid "Royale"
 msgstr ""
 
 msgctxt "#30009"
@@ -57,7 +55,7 @@ msgid "Emulates a CRT display. Highly advanced multi-pass shader. Resource inten
 msgstr ""
 
 msgctxt "#30010"
-msgid "NTSC Filter"
+msgid "Television"
 msgstr ""
 
 msgctxt "#30011"
@@ -69,11 +67,11 @@ msgid "Replicates the analog signals that the consoles output to the TV. Feature
 msgstr ""
 
 msgctxt "#30013"
-msgid "NTSC 256px Composite"
+msgid "TV-out"
 msgstr ""
 
 msgctxt "#30014"
-msgid "NTSC/TV-out"
+msgid "NTSC 256px Composite"
 msgstr ""
 
 msgctxt "#30015"
@@ -97,7 +95,7 @@ msgid "xBR-lv2 (fast)"
 msgstr ""
 
 msgctxt "#30020"
-msgid "Attempts to reduce pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm to scale. Simplified lvl2 implementation. Detects 4 edges. Much faster than the standard version, though it sacrifices some quality."
++msgid "Attempts to reduce pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm to scale. Simplified lvl2 implementation. Detects 4 edges. Much faster than the standard version, though it sacrifices some quality."
 msgstr ""
 
 msgctxt "#30021"
@@ -105,7 +103,7 @@ msgid "xBR-mlv4"
 msgstr ""
 
 msgctxt "#30022"
-msgid "Reduces pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm to scale. Latest evolution of the standard xBR algorithm. The interpolation blends pixel colors, so that the final image is smoother than the other versions."
++msgid "Reduces pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm to scale. Latest evolution of the standard xBR algorithm. The interpolation blends pixel colors, so that the final image is smoother than the other versions."
 msgstr ""
 
 msgctxt "#30024"
@@ -113,7 +111,7 @@ msgid "Super Eagle"
 msgstr ""
 
 msgctxt "#30025"
-msgid "Reduces pixelation by smoothing and rounding edges. Uses the Super Eagle algorithm (by Kreed) to scale. Does more blending than other scaling algorithms."
++msgid "Reduces pixelation by smoothing and rounding edges. Uses the Super Eagle algorithm (by Kreed) to scale. Does more blending than other scaling algorithms."
 msgstr ""
 
 msgctxt "#30026"
@@ -141,7 +139,7 @@ msgid "No description."
 msgstr ""
 
 msgctxt "#30032"
-msgid "LCD"
+msgid "LCD Screen"
 msgstr ""
 
 msgctxt "#30033"
@@ -175,4 +173,3 @@ msgstr ""
 msgctxt "#30040"
 msgid "Reduces pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm. Detects 6 edges, which shows as better rounded objects on screen. The interpolation doesn't blend pixel colors."
 msgstr ""
-


### PR DESCRIPTION
The order I chose is roughly -

* Television
* TV-out from oldest to newest
* CRT display
* LCD from darkest to brighest
* Scaling shader from smoother to clearer
* Handled color shaders from oldest to newest (None of these worked for me)

I also flipped name and category. I feel that name are more an implementation detail, and should have less prominence than the category.

![screenshot000](https://user-images.githubusercontent.com/531482/29825714-13e55e80-8c8a-11e7-8dd6-c7292e77299d.png)
