### PR TITLE
Move color shaders next to LCD shaders

### DIFF
--- a/game.shader.presets/resources/ShaderPresetsDefault.xml
+++ b/game.shader.presets/resources/ShaderPresetsDefault.xml
@@ -82,6 +82,42 @@
         <description>30002</description>
     </preset>
     <preset>
+        <path>libretro/hlsl/handheld/lcd-grid-v2-vba-color.cgp</path>
+        <!-- LCD Screen -->
+        <name>30032</name>
+        <!-- VBA Emulator -->
+        <category>30029</category>
+        <!-- No description. -->
+        <description>30031</description>
+    </preset>
+    <preset>
+        <path>libretro/hlsl/handheld/lcd-grid-v2-gba-color.cgp</path>
+        <!-- LCD Screen -->
+        <name>30032</name>
+        <!-- Game Boy Advance -->
+        <category>30026</category>
+        <!-- No description. -->
+        <description>30031</description>
+    </preset>
+    <preset>
+        <path>libretro/hlsl/handheld/lcd-grid-v2-nds-color.cgp</path>
+        <!-- LCD Screen -->
+        <name>30032</name>
+        <!-- Nintendo DS -->
+        <category>30027</category>
+        <!-- No description. -->
+        <description>30031</description>
+    </preset>
+    <preset>
+        <path>libretro/hlsl/handheld/lcd-grid-v2-psp-color.cgp</path>
+        <!-- LCD Screen -->
+        <name>30032</name>
+        <!-- PlayStation Portable -->
+        <category>30028</category>
+        <!-- No description. -->
+        <description>30031</description>
+    </preset>
+    <preset>
         <path>libretro/hlsl/eagle/super-eagle.cgp</path>
         <!-- Scaling Shader -->
         <name>30018</name>
@@ -126,40 +162,4 @@
         <!-- Attempts to reduce pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm to scale, by detecting edges and interpolating pixels along them. Latest evolution of the standard xBR algorithm. The interpolation blends pixel colors, so that the final image is smoother than the other versions. -->
 <!--        <description>30022</description> -->
 <!--    </preset> -->
-    <preset>
-        <path>libretro/hlsl/handheld/lcd-grid-v2-vba-color.cgp</path>
-        <!-- Handheld -->
-        <name>30030</name>
-        <!-- VBA Colors -->
-        <category>30029</category>
-        <!-- No description. -->
-        <description>30031</description>
-    </preset>
-    <preset>
-        <path>libretro/hlsl/handheld/lcd-grid-v2-gba-color.cgp</path>
-        <!-- Handheld -->
-        <name>30030</name>
-        <!-- GBA Colors -->
-        <category>30026</category>
-        <!-- No description. -->
-        <description>30031</description>
-    </preset>
-    <preset>
-        <path>libretro/hlsl/handheld/lcd-grid-v2-nds-color.cgp</path>
-        <!-- Handheld -->
-        <name>30030</name>
-        <!-- NDS Colors -->
-        <category>30027</category>
-        <!-- No description. -->
-        <description>30031</description>
-    </preset>
-    <preset>
-        <path>libretro/hlsl/handheld/lcd-grid-v2-psp-color.cgp</path>
-        <!-- Handheld -->
-        <name>30030</name>
-        <!-- PSP Colors -->
-        <category>30028</category>
-        <!-- No description. -->
-        <description>30031</description>
-    </preset>
 </presets>

--- a/game.shader.presets/resources/language/resource.language.en_gb/strings.po
+++ b/game.shader.presets/resources/language/resource.language.en_gb/strings.po
@@ -115,24 +115,22 @@ msgctxt "#30025"
 msgstr ""
 
 msgctxt "#30026"
-msgid "GBA Colors"
+msgid "Game Boy Advance"
 msgstr ""
 
 msgctxt "#30027"
-msgid "NDS Colors"
+msgid "Nintendo DS"
 msgstr ""
 
 msgctxt "#30028"
-msgid "PSP Colors"
+msgid "PlayStation Portable"
 msgstr ""
 
 msgctxt "#30029"
-msgid "VBA Colors"
+msgid "VBA Emulator"
 msgstr ""
 
-msgctxt "#30030"
-msgid "Handheld"
-msgstr ""
+#empty string with id 30030
 
 msgctxt "#30031"
 msgid "No description."
@@ -163,7 +161,7 @@ msgid "xBR-lv3"
 msgstr ""
 
 msgctxt "#30038"
-msgid "xBR-lv3 No Blend"
+msgid "xBR-lv3 (no blend)"
 msgstr ""
 
 msgctxt "#30039"


### PR DESCRIPTION
All these handhelds use LCDs, so move them next to the LCD shaders.