### PR TITLE
Make descriptions more concise

### DIFF
--- a/game.shader.presets/resources/ShaderPresetsDefault.xml
+++ b/game.shader.presets/resources/ShaderPresetsDefault.xml
@@ -2,39 +2,30 @@
 <presets>
     <preset>
         <path>libretro/hlsl/ntsc/ntsc.cgp</path>
-        <!-- Television -->
-        <name>30010</name>
-        <!-- NTSC -->
+        <!-- TV-out -->
+        <name>30013</name>
+        <!-- NTSC RF -->
         <category>30011</category>
-        <!-- Replicates the analog signals that the consoles output to the TV. Features color distortion, blurring, NTSC color artifacts and dot crawl. -->
+        <!-- Replicates the analog signal that the console outputs to the TV through a coaxial RF connector. Features color distortion, blurring, NTSC color artifacts and dot crawl. -->
         <description>30012</description>
     </preset>
     <preset>
         <path>libretro/hlsl/cgp/tvout/tvout+ntsc-256px-composite.cgp</path>
         <!-- TV-out -->
         <name>30013</name>
-        <!-- NTSC 256px Composite -->
+        <!-- NTSC Composite -->
         <category>30014</category>
-        <!-- Replicates the analog signals that the consoles output to the TV. 256px downscale resolution. Emulates composite connector. Features color distortion, blurring, NTSC color artifacts. -->
+        <!-- Replicates the analog signal that the console outputs to the TV through the composite connector. Features color distortion, blurring, NTSC color artifacts. -->
         <description>30016</description>
-    </preset>
-    <preset>
-        <path>libretro/hlsl/cgp/tvout/tvout+ntsc-256px-svideo.cgp</path>
-        <!-- TV-out -->
-        <name>30013</name>
-        <!-- NTSC 256px S-video -->
-        <category>30035</category>
-        <!-- Replicates the analog signals that the consoles output to the TV. 256px downscale resolution. Emulates S-Video connector. Features color distortion, blurring, NTSC color artifacts. -->
-        <description>30015</description>
     </preset>
     <preset>
         <path>libretro/hlsl/cgp/tvout/tvout+ntsc-320px-svideo.cgp</path>
         <!-- TV-out -->
         <name>30013</name>
-        <!-- NTSC 320px S-video -->
-        <category>30036</category>
-        <!-- Replicates the analog signals that the consoles output to the TV. 320px downscale resolution. Emulates S-Video connector. Features color distortion, blurring, NTSC color artifacts. -->
-        <description>30017</description>
+        <!-- NTSC S-video -->
+        <category>30035</category>
+        <!-- Replicates the analog signal that the console outputs to the TV through a S-Video connector. Features color distortion, blurring, NTSC color artifacts. -->
+        <description>30015</description>
     </preset>
     <preset>
         <path>libretro/hlsl/crt/4xbr-hybrid-crt-b.cgp</path>
@@ -42,7 +33,7 @@
         <name>30004</name>
         <!-- 4xbr Hybrid -->
         <category>30003</category>
-        <!-- Emulates a CRT display. Basic. Features scan-lines, color correction, gamma correction and sharpening. -->
+        <!-- Emulates a CRT display. Features scan-lines, color correction, gamma correction and sharpening. -->
         <description>30005</description>
     </preset>
 <!--    <preset> -->
@@ -51,7 +42,7 @@
 <!--        <name>30004</name> -->
         <!-- Hylian Multipass -->
 <!--        <category>30006</category> -->
-        <!-- Emulates a CRT display. Advanced and fast. Aims only for picture quality, so it avoids effects that degrade the image. Features scan-lines, color correction, gamma correction, sharpening, CRT phosphor and CRT beam effects. -->
+        <!-- Emulates a CRT display. Features scan-lines, color correction, gamma correction, sharpening, CRT phosphor and CRT beam effects. -->
 <!--        <description>30007</description> -->
 <!--    </preset> -->
 <!--    <preset> -->
@@ -60,7 +51,7 @@
 <!--        <name>30004</name> -->
         <!-- Royale -->
 <!--        <category>30008</category> -->
-        <!-- Emulates a CRT display. Highly advanced multi-pass shader. Resource intensive. Features scan-lines, color correction, gamma correction, sharpening, CRT phosphor emulation, halation, refractive diffusion, curvature and anti-aliasing. -->
+        <!-- Emulates a CRT display. Resource intensive. Features scan-lines, color correction, gamma correction, sharpening, CRT phosphor emulation, halation, refractive diffusion, curvature and anti-aliasing. -->
 <!--        <description>30009</description> -->
 <!--    </preset> -->
     <preset>
@@ -82,21 +73,12 @@
         <description>30002</description>
     </preset>
     <preset>
-        <path>libretro/hlsl/handheld/lcd-grid-v2-vba-color.cgp</path>
-        <!-- LCD Screen -->
-        <name>30032</name>
-        <!-- VBA Emulator -->
-        <category>30029</category>
-        <!-- No description. -->
-        <description>30031</description>
-    </preset>
-    <preset>
         <path>libretro/hlsl/handheld/lcd-grid-v2-gba-color.cgp</path>
         <!-- LCD Screen -->
         <name>30032</name>
         <!-- Game Boy Advance -->
         <category>30026</category>
-        <!-- No description. -->
+        <!-- Replicates the 3-by-2-inch color LCD screen of the Game Boy Advance. -->
         <description>30031</description>
     </preset>
     <preset>
@@ -105,8 +87,8 @@
         <name>30032</name>
         <!-- Nintendo DS -->
         <category>30027</category>
-        <!-- No description. -->
-        <description>30031</description>
+        <!-- Replecates the TFT LCD screen of the Nintendo DS. -->
+        <description>30030</description>
     </preset>
     <preset>
         <path>libretro/hlsl/handheld/lcd-grid-v2-psp-color.cgp</path>
@@ -114,8 +96,8 @@
         <name>30032</name>
         <!-- PlayStation Portable -->
         <category>30028</category>
-        <!-- No description. -->
-        <description>30031</description>
+        <!-- Replicates the 4.3-inch TFT LCD screen of the PlayStation Portable. -->
+        <description>30029</description>
     </preset>
     <preset>
         <path>libretro/hlsl/eagle/super-eagle.cgp</path>
@@ -123,7 +105,7 @@
         <name>30018</name>
         <!-- Super Eagle -->
         <category>30024</category>
-        <!-- Attempts to reduce pixelation by smoothing and rounding edges. Uses the Super Eagle algorithm (by Kreed) to scale, by detecting edges and interpolating pixels along them. Does more blending than other scaling algorithms. -->
+        <!-- Reduces pixelation by smoothing and rounding edges. Uses the Super Eagle algorithm (by Kreed). -->
         <description>30025</description>
     </preset>
     <preset>
@@ -132,7 +114,7 @@
         <name>30018</name>
         <!-- xBR-lv2 -->
         <category>30019</category>
-        <!-- Attempts to reduce pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm to scale, by detecting edges and interpolating pixels along them. -->
+        <!-- Reduces pixelation by smoothing and rounding edges. Uses the xBR algorithm (by rules). -->
         <description>30020</description>
     </preset>
     <preset>
@@ -141,16 +123,16 @@
         <name>30018</name>
         <!-- xBR-lv3 -->
         <category>30037</category>
-        <!-- Reduces pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm. Detects 6 edges, which shows as better rounded objects on screen. The interpolation blends pixel colors, so the final image is smoother than noblend versions. -->
+        <!-- Reduces pixelation by smoothing and rounding edges. Uses the xBR algorithm (by rules). The final image is smoother than no-blend version. -->
         <description>30039</description>
     </preset>
     <preset>
         <path>libretro/hlsl/xbr/xbr-lv3-noblend.cgp</path>
         <!-- Scaling Shader -->
         <name>30018</name>
-        <!-- xBR-lv3 No Blend -->
+        <!-- xBR-lv3 (no blend) -->
         <category>30038</category>
-        <!-- Reduces pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm. Detects 6 edges, which shows as better rounded objects on screen. The interpolation doesn't blend pixel colors. -->
+        <!-- Reduces pixelation by smoothing and rounding edges. Uses the xBR algorithm (by rules). The interpolation doesn't blend pixel colors. -->
         <description>30040</description>
     </preset>
 <!--    <preset> -->
@@ -159,7 +141,7 @@
 <!--        <name>30018</name> -->
         <!-- xBR-mlv4 -->
 <!--        <category>30021</category> -->
-        <!-- Attempts to reduce pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm to scale, by detecting edges and interpolating pixels along them. Latest evolution of the standard xBR algorithm. The interpolation blends pixel colors, so that the final image is smoother than the other versions. -->
+        <!-- Reduces pixelation by smoothing and rounding edges. Uses the latest evolution of the standard xBR algorithm. The image is smoother than other versions. -->
 <!--        <description>30022</description> -->
 <!--    </preset> -->
 </presets>

--- a/game.shader.presets/resources/language/resource.language.en_gb/strings.po
+++ b/game.shader.presets/resources/language/resource.language.en_gb/strings.po
@@ -35,7 +35,7 @@ msgid "CRT Display"
 msgstr ""
 
 msgctxt "#30005"
-msgid "Emulates a CRT display. Basic. Features scan-lines, color correction, gamma correction and sharpening."
+msgid "Emulates a CRT display. Features scan-lines, color correction, gamma correction and sharpening."
 msgstr ""
 
 msgctxt "#30006"
@@ -43,7 +43,7 @@ msgid "Hylian Multipass"
 msgstr ""
 
 msgctxt "#30007"
-msgid "Emulates a CRT display. Advanced and fast. Aims only for picture quality, so it avoids effects that degrade the image. Features scan-lines, color correction, gamma correction, sharpening, CRT phosphor and CRT beam effects."
+msgid "Emulates a CRT display. Features scan-lines, color correction, gamma correction, sharpening, CRT phosphor and CRT beam effects."
 msgstr ""
 
 msgctxt "#30008"
@@ -51,19 +51,17 @@ msgid "Royale"
 msgstr ""
 
 msgctxt "#30009"
-msgid "Emulates a CRT display. Highly advanced multi-pass shader. Resource intensive. Features scan-lines, color correction, gamma correction, sharpening, CRT phosphor emulation, halation, refractive diffusion, curvature and anti-aliasing."
+msgid "Emulates a CRT display. Resource intensive. Features scan-lines, color correction, gamma correction, sharpening, CRT phosphor emulation, halation, refractive diffusion, curvature and anti-aliasing."
 msgstr ""
 
-msgctxt "#30010"
-msgid "Television"
-msgstr ""
+#empty string with id 30010
 
 msgctxt "#30011"
-msgid "NTSC"
+msgid "NTSC RF"
 msgstr ""
 
 msgctxt "#30012"
-msgid "Replicates the analog signals that the consoles output to the TV. Feature color distortion, blurring, NTSC color artifacts and dot crawl."
+msgid "Replicates the analog signal that the console outputs to the TV through a coaxial RF connector. Features color distortion, blurring, NTSC color artifacts and dot crawl."
 msgstr ""
 
 msgctxt "#30013"
@@ -71,20 +69,18 @@ msgid "TV-out"
 msgstr ""
 
 msgctxt "#30014"
-msgid "NTSC 256px Composite"
+msgid "NTSC Composite"
 msgstr ""
 
 msgctxt "#30015"
-msgid "Replicates the analog signals that the consoles output to the TV. 256px downscale resolution. Emulates S-Video connector. Features color distortion, blurring, NTSC color artifacts."
+msgid "Replicates the analog signal that the console outputs to the TV through a S-Video connector. Features color distortion, blurring, NTSC color artifacts."
 msgstr ""
 
 msgctxt "#30016"
-msgid "Replicates the analog signals that the consoles output to the TV. 256px downscale resolution. Emulates composite connector. Features color distortion, blurring, NTSC color artifacts."
+msgid "Replicates the analog signal that the console outputs to the TV through a composite connector. Features color distortion, blurring, NTSC color artifacts."
 msgstr ""
 
-msgctxt "#30017"
-msgid "Replicates the analog signals that the consoles output to the TV. 320px downscale resolution. Emulates S-Video connector. Features color distortion, blurring, NTSC color artifacts."
-msgstr ""
+#empty string with id 30017
 
 msgctxt "#30018"
 msgid "Scaling Shader"
@@ -95,7 +91,7 @@ msgid "xBR-lv2 (fast)"
 msgstr ""
 
 msgctxt "#30020"
-+msgid "Attempts to reduce pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm to scale. Simplified lvl2 implementation. Detects 4 edges. Much faster than the standard version, though it sacrifices some quality."
+msgid "Reduces pixelation by smoothing and rounding edges. Uses the xBR algorithm (by rules)."
 msgstr ""
 
 msgctxt "#30021"
@@ -103,7 +99,7 @@ msgid "xBR-mlv4"
 msgstr ""
 
 msgctxt "#30022"
-+msgid "Reduces pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm to scale. Latest evolution of the standard xBR algorithm. The interpolation blends pixel colors, so that the final image is smoother than the other versions."
+msgid "Reduces pixelation by smoothing and rounding edges. Uses the latest evolution of the standard xBR algorithm. The image is smoother than other versions."
 msgstr ""
 
 msgctxt "#30024"
@@ -111,7 +107,7 @@ msgid "Super Eagle"
 msgstr ""
 
 msgctxt "#30025"
-+msgid "Reduces pixelation by smoothing and rounding edges. Uses the Super Eagle algorithm (by Kreed) to scale. Does more blending than other scaling algorithms."
+msgid "Reduces pixelation by smoothing and rounding edges. Uses the Super Eagle algorithm (by Kreed)."
 msgstr ""
 
 msgctxt "#30026"
@@ -127,13 +123,15 @@ msgid "PlayStation Portable"
 msgstr ""
 
 msgctxt "#30029"
-msgid "VBA Emulator"
+msgid "Replicates the 4.3-inch TFT LCD screen of the PlayStation Portable."
 msgstr ""
 
-#empty string with id 30030
+msgctxt "#30030"
+msgid "Replecates the TFT LCD screen of the Nintendo DS."
+msgstr ""
 
 msgctxt "#30031"
-msgid "No description."
+msgid "Replicates the 3-by-2-inch color LCD screen of the Game Boy Advance."
 msgstr ""
 
 msgctxt "#30032"
@@ -145,16 +143,14 @@ msgid "LCD3x"
 msgstr ""
 
 msgctxt "#30034"
-msgid "LCD3x is an image filter that simulates the aspect of an LCD screen while at the same time increasing the size of the source image."
+msgid "LCD3x is an image filter by gigaherz that simulates the aspect of an LCD screen while at the same time increasing the size of the source image."
 msgstr ""
 
 msgctxt "#30035"
-msgid "NTSC 256px S-video"
+msgid "NTSC S-video"
 msgstr ""
 
-msgctxt "#30036"
-msgid "NTSC 320px S-video"
-msgstr ""
+#empty string with id 30036
 
 msgctxt "#30037"
 msgid "xBR-lv3"
@@ -165,9 +161,9 @@ msgid "xBR-lv3 (no blend)"
 msgstr ""
 
 msgctxt "#30039"
-msgid "Reduces pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm. Detects 6 edges, which shows as better rounded objects on screen. The interpolation blends pixel colors, so the final image is smoother than noblend versions."
+msgid "Reduces pixelation by smoothing and rounding edges. Uses the xBR algorithm (by rules). The final image is smoother than no-blend version."
 msgstr ""
 
 msgctxt "#30040"
-msgid "Reduces pixelation by smoothing and rounding edges. Uses the xBR (scale by rules) algorithm. Detects 6 edges, which shows as better rounded objects on screen. The interpolation doesn't blend pixel colors."
+msgid "Reduces pixelation by smoothing and rounding edges. Uses the xBR algorithm (by rules). The interpolation doesn't blend pixel colors."
 msgstr ""


### PR DESCRIPTION
This rewords the descriptions to be more concise, and also drops the NTSC 256px S-Video shader in favor of the NTSC 320px S-Video shader. It also drops the VBA shader.