### PR TITLE
Fix compiler warning

### DIFF
--- a/src/addon.h
+++ b/src/addon.h
@@ -21,10 +21,11 @@
  */
 
 #include <kodi/addon-instance/ShaderPreset.h>
+#include <kodi/AddonBase.h>
 
 struct rarch_video_shader;
 
-class CShaderPreset
+class ATTRIBUTE_HIDDEN CShaderPreset
   : public kodi::addon::CAddonBase,
     public kodi::addon::CInstanceShaderPreset
 {


### PR DESCRIPTION
Warning was:

```
addon.cpp:22:0:
addon.h:27:7: warning: ‘CShaderPreset’ declared with greater visibility than the type of its field ‘CShaderPreset::<anonymous>’ [-Wattributes]
 class CShaderPreset
       ^~~~~~~~~~~~~

addon.h:27:7: warning: ‘CShaderPreset’ declared with greater visibility than its base ‘kodi::addon::CAddonBase’ [-Wattributes]
```